### PR TITLE
add nifty extension for configuring fail-fast exceptions (`.Options(o…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1273,12 +1273,14 @@
 
 * Fix bug in the "enforce exclusive saga access" feature that would result in an exception, if the same lock bucket got hit more than once
 
-## 6.0.0-b07
+## 6.0.0-b08
 
 * Move data bus configuration to main configurer, so now you can go `.DataBus(d => d.StoreInFileSystem(@"\\network-path\folder"))`
 * Add automatic claim check support, so you can have big messages transferred as data bus attachments by going e.g. `d.SendBigMessagesAsAttachments(bodySizeThresholdBytes: 200*1000)`
 * Move cancellation support into the backoff strategy - thanks [nativenolde]
 * Change log messages when changing number of workers to include the bus name - thanks [nativenolde]
+* Add nifty fail fast helper on options configurer: `.Options(o => o.FailFastOn<TException>())` or `.Options(o => o.FailFastOn<TException>(when: ex => ex.Message.Contains("whatever")))`
+* Change `RebusTransactionScope` so it can be used inside Rebus handlers (in case that would be handy to anyone)
 
 ---
 

--- a/Rebus.Tests/Assumptions/CheckBehaviorWhenCreatingRebusTransactionScopeInsideRebusHandler.cs
+++ b/Rebus.Tests/Assumptions/CheckBehaviorWhenCreatingRebusTransactionScopeInsideRebusHandler.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.Config;
+using Rebus.Retry.FailFast;
+using Rebus.Tests.Contracts;
+using Rebus.Transport;
+using Rebus.Transport.InMem;
+// ReSharper disable ArgumentsStyleAnonymousFunction
+#pragma warning disable 1998
+
+namespace Rebus.Tests.Assumptions
+{
+    [TestFixture]
+    [Description("This test verifies that it's not possible to mess up Rebus' ambient handler transaction by using a RebusTransactionScope inside the handler")]
+    public class CheckBehaviorWhenCreatingRebusTransactionScopeInsideRebusHandler : FixtureBase
+    {
+        [Test]
+        public async Task CheckIt()
+        {
+            var activator = Using(new BuiltinHandlerActivator());
+            var network = new InMemNetwork();
+            var rolledBackMessageReceived = new ManualResetEvent(initialState: false);
+
+            activator.Handle<ThisMessageShouldNotBeSent>(async _ => rolledBackMessageReceived.Set());
+
+            activator.Handle<string>(async (bus, context, message) =>
+            {
+                using (var scope = new RebusTransactionScope())
+                {
+                    await scope.CompleteAsync();
+                }
+
+                await bus.SendLocal(new ThisMessageShouldNotBeSent());
+
+                throw new InvalidOperationException("OH NO!");
+            });
+
+            Configure.With(activator)
+                .Transport(t => t.UseInMemoryTransport(network, "queue-name"))
+                .Options(o => o.FailFastOn<InvalidOperationException>(when: exception => exception.Message.Contains("OH NO!")))
+                .Start();
+
+            await activator.Bus.SendLocal("HEJ MED DIG MIN VEN");
+
+            Assert.That(rolledBackMessageReceived.WaitOne(TimeSpan.FromSeconds(3)), Is.False,
+                "Did not expect to receive the ThisMessageShouldNotBeSent, because its Rebus handler transaction was rolled back by an exception");
+        }
+
+        class ThisMessageShouldNotBeSent { }
+    }
+}

--- a/Rebus.Tests/Transport/InMem/InMemTransportBasicSendReceive.cs
+++ b/Rebus.Tests/Transport/InMem/InMemTransportBasicSendReceive.cs
@@ -1,0 +1,8 @@
+﻿using NUnit.Framework;
+using Rebus.Tests.Contracts.Transports;
+
+namespace Rebus.Tests.Transport.InMem
+{
+    [TestFixture]
+    public class InMemTransportBasicSendReceive : BasicSendReceive<InMemTransportFactory> { }
+}

--- a/Rebus.Tests/Transport/InMem/InMemTransportFactory.cs
+++ b/Rebus.Tests/Transport/InMem/InMemTransportFactory.cs
@@ -1,16 +1,9 @@
-﻿using NUnit.Framework;
-using Rebus.Tests.Contracts.Transports;
+﻿using Rebus.Tests.Contracts.Transports;
 using Rebus.Transport;
 using Rebus.Transport.InMem;
 
 namespace Rebus.Tests.Transport.InMem
 {
-    [TestFixture]
-    public class InMemTransportBasicSendReceive : BasicSendReceive<InMemTransportFactory> { }
-
-    [TestFixture]
-    public class InMemTransportMessageExpiration : MessageExpiration<InMemTransportFactory> { }
-
     public class InMemTransportFactory : ITransportFactory
     {
         readonly InMemNetwork _network = new InMemNetwork();

--- a/Rebus.Tests/Transport/InMem/InMemTransportMessageExpiration.cs
+++ b/Rebus.Tests/Transport/InMem/InMemTransportMessageExpiration.cs
@@ -1,0 +1,8 @@
+﻿using NUnit.Framework;
+using Rebus.Tests.Contracts.Transports;
+
+namespace Rebus.Tests.Transport.InMem
+{
+    [TestFixture]
+    public class InMemTransportMessageExpiration : MessageExpiration<InMemTransportFactory> { }
+}

--- a/Rebus.Tests/Transport/InMem/TestInMemTransport.cs
+++ b/Rebus.Tests/Transport/InMem/TestInMemTransport.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rebus.Messages;
+using Rebus.Tests.Contracts;
+using Rebus.Transport;
+using Rebus.Transport.InMem;
+
+namespace Rebus.Tests.Transport.InMem
+{
+    [TestFixture]
+    [Description("Verifies the most basic thing about in-mem transport's ability to enlist in an ongoing transaction")]
+    public class TestInMemTransport : FixtureBase
+    {
+        [Test]
+        public async Task VeryBasicTransactionThing()
+        {
+            const string destinationQueueName = "another-queue";
+
+            var network = new InMemNetwork();
+
+            network.CreateQueue(destinationQueueName);
+
+            var transport = new InMemTransport(network, "test-queue");
+
+            transport.Initialize();
+
+            using (var scope = new RebusTransactionScope())
+            {
+                var headers = new Dictionary<string, string> { { Headers.MessageId, Guid.NewGuid().ToString() } };
+
+                await transport.Send(
+                    destinationAddress: destinationQueueName,
+                    message: new TransportMessage(headers, new byte[] { 1, 2, 3 }),
+                    context: scope.TransactionContext
+                );
+
+                Assert.That(network.Count(destinationQueueName), Is.EqualTo(0),
+                    $"Expected ZERO messages in queue '{destinationQueueName}' at this point, because the scope was not completed");
+
+                await scope.CompleteAsync();
+            }
+
+            Assert.That(network.Count(destinationQueueName), Is.EqualTo(1),
+                $"Expected 1 message in queue '{destinationQueueName}' at this point, because the scope is completed now");
+        }
+    }
+}

--- a/Rebus/Retry/FailFast/FailFastConfigurationExtension.cs
+++ b/Rebus/Retry/FailFast/FailFastConfigurationExtension.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Rebus.Config;
+
+namespace Rebus.Retry.FailFast
+{
+    /// <summary>
+    /// Extension methods for helping with configuration fail-fast behavior
+    /// </summary>
+    public static class FailFastConfigurationExtension
+    {
+        /// <summary>
+        /// Decorates the current <see cref="IFailFastChecker"/> with a filter that causes Rebus to fail fast on exceptions of type
+        /// <typeparamref name="TException"/> (optionally also requiring it to satisfy the when <paramref name="when"/>)
+        /// </summary>
+        public static void FailFastOn<TException>(this OptionsConfigurer configurer, Func<TException, bool> when = null) where TException : Exception
+        {
+            if (configurer == null) throw new ArgumentNullException(nameof(configurer));
+
+            configurer.Decorate<IFailFastChecker>(c =>
+            {
+                var failFastChecker = c.Get<IFailFastChecker>();
+
+                return new FailFastOnSpecificExceptionTypeAndPredicate<TException>(failFastChecker, when);
+            });
+        }
+
+        class FailFastOnSpecificExceptionTypeAndPredicate<TException> : IFailFastChecker where TException : Exception
+        {
+            readonly IFailFastChecker _failFastChecker;
+            readonly Func<TException, bool> _predicate;
+
+            public FailFastOnSpecificExceptionTypeAndPredicate(IFailFastChecker failFastChecker, Func<TException, bool> predicate = null)
+            {
+                _failFastChecker = failFastChecker ?? throw new ArgumentNullException(nameof(failFastChecker));
+                _predicate = predicate ?? (_ => true);
+            }
+
+            public bool ShouldFailFast(string messageId, Exception exception)
+            {
+                return exception is TException specificException && _predicate(specificException)
+                       || _failFastChecker.ShouldFailFast(messageId, exception);
+            }
+        }
+    }
+}

--- a/Rebus/Transport/InMem/InMemNetwork.cs
+++ b/Rebus/Transport/InMem/InMemNetwork.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using Rebus.Extensions;
 using Rebus.Logging;
 using Rebus.Messages;
-using Rebus.Transport.InMem;
 
 namespace Rebus.Transport.InMem
 {
@@ -112,8 +111,7 @@ namespace Rebus.Transport.InMem
 
             while (true)
             {
-                InMemTransportMessage message;
-                if (!messageQueue.TryDequeue(out message)) return null;
+                if (!messageQueue.TryDequeue(out var message)) return null;
 
                 var messageId = message.Headers.GetValueOrNull(Headers.MessageId) ?? "<no message ID>";
 

--- a/Rebus/Transport/RebusTransactionScope.cs
+++ b/Rebus/Transport/RebusTransactionScope.cs
@@ -13,6 +13,7 @@ namespace Rebus.Transport
     public class RebusTransactionScope : IDisposable
     {
         readonly TransactionContext _transactionContext = new TransactionContext();
+        readonly ITransactionContext _previousTransactionContext;
 
         /// <summary>
         /// Creates a new transaction context and mounts it on <see cref="AmbientTransactionContext.Current"/>, making it available for Rebus
@@ -20,6 +21,7 @@ namespace Rebus.Transport
         /// </summary>
         public RebusTransactionScope()
         {
+            _previousTransactionContext = AmbientTransactionContext.Current;
             AmbientTransactionContext.SetCurrent(_transactionContext);
         }
 
@@ -49,7 +51,7 @@ namespace Rebus.Transport
             }
             finally
             {
-                AmbientTransactionContext.SetCurrent(null);
+                AmbientTransactionContext.SetCurrent(_previousTransactionContext);
             }
         }
     }


### PR DESCRIPTION
… => o.FailFastOn<TException>())`) and make `RebusTransactionScope` capable of being used inside Rebus handlers

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
